### PR TITLE
HH-80904 Do not fall when not valid js code

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hh.ru/babel-plugin-static-value-extractor",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "lib/index.js",
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/index.js
+++ b/src/index.js
@@ -26,10 +26,12 @@ const BABEL_PARSING_OPTS = {
 const noop = () => {};
 
 const extractStaticValueFromCode = (code, opts = {}, cb = noop) => {
-    const ast = babylon.parse(code.toString(ENCODING), BABEL_PARSING_OPTS);
-    const traverser = getTraverser(cb, opts);
-
-    traverse(ast, traverser);
+    try {
+        const ast = babylon.parse(code.toString(ENCODING), BABEL_PARSING_OPTS);
+        const traverser = getTraverser(cb, opts);
+    
+        traverse(ast, traverser);
+    } catch (ignore) {}
 };
 
 export const extractStaticValueFromFile = (file, opts = {}, cb = noop) => {


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-80904

### Проблема
Если js не валиден, то естественно падает  построение AST, нам не нужно падать, об этом сообщит сборщик, и в вотч режиме нужно перезапускать сборку =(

### Решение
Обернем парсинг в try, catch. Вывод ошибки игнорируем, сборщик в любом случае сообщает о ней.
