### PR TITLE
0.4.1 fix bug not importing props from *.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hh.ru/babel-plugin-static-value-extractor",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "lib/index.js",
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/traverser.js
+++ b/src/traverser.js
@@ -34,8 +34,16 @@ export default (cb, opts = {}) => {
 
         if (fs.existsSync(importPath)) {
             importDeclarationPaths.push(nodePath.resolve(importPath, defaultFileName));
-        } else if (fs.existsSync(`${importPath}.jsx`)) {
+            return;
+        }
+
+        if (fs.existsSync(`${importPath}.jsx`)) {
             importDeclarationPaths.push(`${importPath}.jsx`);
+            return;
+        }
+
+        if (fs.existsSync(`${importPath}.js`)) {
+            importDeclarationPaths.push(`${importPath}.js`);
         }
     };
 

--- a/test/fixtures/replace-path/Component/after.jsx
+++ b/test/fixtures/replace-path/Component/after.jsx
@@ -1,7 +1,6 @@
-class after {
-    static customProps = {
-        bar: 'customProps-after',
-    };
-}
+const after = (val) => {val};
+after.customProps = {
+    bar: 'customProps-after',
+};
 
-export default after;
+export const After = after;

--- a/test/fixtures/replace-path/Component/index.js
+++ b/test/fixtures/replace-path/Component/index.js
@@ -1,4 +1,4 @@
-import after from './before';
+import { After } from './before';
 
 const component = () => {};
 

--- a/test/index.js
+++ b/test/index.js
@@ -17,21 +17,20 @@ describe('Extract static value from glob', () => {
 
             del.sync(path.join(fixtureDir, 'expected/*.js'));
 
-            extractStaticValueFromGlob([path.join(fixtureDir, '/Component/*.jsx')], {
-                staticPropName: 'customProps',
-                saveFilePath: path.join(fixtureDir, 'expected'),
-                pathsToReplace: { './before': './after' },
-                saveFileExt: 'js',
-                saveFileName: 'Component'
-            });
+            extractStaticValueFromGlob(
+                [path.join(fixtureDir, '/Component/*.jsx'), path.join(fixtureDir, '/Component/*.js')],
+                {
+                    staticPropName: 'customProps',
+                    saveFilePath: path.join(fixtureDir, 'expected'),
+                    pathsToReplace: { './before': './after' },
+                    saveFileExt: 'js',
+                    saveFileName: 'Component',
+                }
+            );
 
-            const expected = fs.readFileSync(
-                path.join(fixtureDir, 'expected/Component.js')
-            ).toString();
+            const expected = fs.readFileSync(path.join(fixtureDir, 'expected/Component.js')).toString();
 
-            const actual = fs.readFileSync(
-                path.join(fixtureDir, './actual.js')
-            ).toString();
+            const actual = fs.readFileSync(path.join(fixtureDir, './actual.js')).toString();
 
             assert.equal(trim(actual), trim(expected));
         });


### PR DESCRIPTION
* prettier `test/index.js`
* get props from `*.js` file and test it
* test get certain fields from imported object