### PR TITLE
HH-126093 Add constant traversing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hh.ru/babel-plugin-static-value-extractor",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "main": "lib/index.js",
   "devDependencies": {
     "@babel/cli": "^7.5.0",

--- a/src/traverser.js
+++ b/src/traverser.js
@@ -65,7 +65,7 @@ export default (cb, opts = {}) => {
 
         VariableDeclarator: {
             enter(path) {
-                if (constantName && path.node.id.name === constantName) {
+                if (constantName && path.node.id.name === constantName && types.isProgram(path.parentPath.parent)) {
                     staticProps = getConcatenatedStaticProps(staticProps, path.node.init);
                 }
             },

--- a/src/traverser.js
+++ b/src/traverser.js
@@ -32,7 +32,7 @@ const replacePath = (path, pathsToReplace = {}) =>
 export default (cb, opts = {}) => {
     let staticProps = [];
     const currentFileDir = nodePath.parse(opts.filename).dir;
-    const { staticPropName, pathsToReplace } = opts;
+    const { staticPropName, pathsToReplace, constantName } = opts;
     const importDeclarationPaths = [];
 
     const processImports = (filePath) => {
@@ -60,6 +60,14 @@ export default (cb, opts = {}) => {
         Program: {
             exit() {
                 cb(staticProps, importDeclarationPaths);
+            },
+        },
+
+        VariableDeclarator: {
+            enter(path) {
+                if (constantName && path.node.id.name === constantName) {
+                    staticProps = getConcatenatedStaticProps(staticProps, path.node.init);
+                }
             },
         },
 

--- a/test/fixtures/include-props-ts/Component/Index.tsx
+++ b/test/fixtures/include-props-ts/Component/Index.tsx
@@ -1,24 +1,33 @@
-import React, { FC } from "react";
-import AdditionalComponent from "./AdditionalComponent";
-import IncludeFolder from "../IncludeFolder";
+import React, { FC } from 'react';
+import AdditionalComponent from './AdditionalComponent';
+import IncludeFolder from '../IncludeFolder';
+
+const CustomProps = {
+    bar: 'const-customProps-1',
+    foo: 'const-customProps-2',
+    nested: {
+        bar: 'const-customProps-3',
+        foo: 'const-customProps-4',
+    },
+};
 
 interface MyCompProps {
-  text: string;
+    text: string;
 }
 
 interface StaticProps {
-  customProps: {
-    [k: string]: string;
-  };
+    customProps: {
+        [k: string]: string;
+    };
 }
 
 const Component: FC<MyCompProps> & StaticProps = ({ text }) => text;
 
 Component.customProps = {
-  bar: "customProps-1",
-  foo: "customProps-2",
+    bar: 'customProps-1',
+    foo: 'customProps-2',
 };
 
-Component.customProps.baz = "customProps-3";
+Component.customProps.baz = 'customProps-3';
 
 export default Component;

--- a/test/fixtures/include-props-ts/Component/Index.tsx
+++ b/test/fixtures/include-props-ts/Component/Index.tsx
@@ -21,7 +21,16 @@ interface StaticProps {
     };
 }
 
-const Component: FC<MyCompProps> & StaticProps = ({ text }) => text;
+const Component: FC<MyCompProps> & StaticProps = ({ text }) => {
+    const CustomProps = {
+        bar: 'const-wrong-1',
+        foo: 'const-wrong-2',
+        nested: {
+            bar: 'const-wrong-3',
+            foo: 'const-wrong-4',
+        },
+    };
+};
 
 Component.customProps = {
     bar: 'customProps-1',

--- a/test/fixtures/include-props-ts/actual.js
+++ b/test/fixtures/include-props-ts/actual.js
@@ -1,1 +1,1 @@
-{"Component":["customProps-1","customProps-2","customProps-3","AdditionalComponent-2","AdditionalComponent-4"]}
+{"Component":["const-customProps-1","const-customProps-2","const-customProps-3","const-customProps-4","customProps-1","customProps-2","customProps-3","AdditionalComponent-2","AdditionalComponent-4"]}

--- a/test/index.js
+++ b/test/index.js
@@ -20,6 +20,7 @@ describe('Extract static value from glob', () => {
             extractStaticValueFromGlob(
                 [path.join(fixtureDir, '/Component/*.?sx'), path.join(fixtureDir, '/Component/*.?s')],
                 {
+                    constantName: 'CustomProps',
                     staticPropName: 'customProps',
                     saveFilePath: path.join(fixtureDir, 'expected'),
                     pathsToReplace: { './before': './after' },


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-126093

Добавил парсинг значений из константы заданной через опции

Для использования объекта с ключами переводов содержащего иерархию в TypeScript — его нужно описать как словарь-константу перед использованием в коде

В случае со статичным пропом, даже при описании его как
```
type TrlKeys = Record<string, string | TrlKeys>
```
при каждом обращении ко вложенному объекту нужно будет совершать проверку что там действительно содержится объект.
Также при таком подходе среда разработки не сможет подсказывать возможные значения и структуру, так как объект имеющий такой тип может быть изменен в коде в любой момент.

В случае если словарь переводов описан как константа в начале файла
```
const TrlKeys = {
    foo: 'some_trl_key',
    bar: 'some_other_key',
    nested: {
        foo: 'some_nested_key'
    }
}
```
TypeScript позволит без каких-либо проверок обращаться к его структуре, определять что во вложенном объекте все записи соответствуют значениям какого-либо enum (если это так) и среда разработки будет подсказывать значения при написании кода