### PR TITLE
HH-159843 speedup values extraction

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,65 +90,53 @@ const mergeProps = (propNames, currentList, added) => {
     });
 };
 
-export const extractStaticValueImportedFilesFromFile = (file, opts = {}, cb = noop, importPaths = []) => {
+export const extractStaticValueImportedFilesFromFile = (topLevelFile, opts = {}, cb = noop) => {
     const propNames = Object.keys(opts.propsToExtract);
-    const relativePath = path.relative(opts.basePath, file);
-
     let staticPropsList = propNames.reduce((agg, name) => ({ ...agg, [name]: [] }), {});
-    const { mtimeMs } = fs.statSync(file);
+    
 
-    function _extractStaticValueImportedFilesFromFile(file, opts, importPaths) {
-        if (opts.include && !opts.include.find((includePath) => file.search(includePath) !== -1)) {
-            return;
-        }
-
-        const { mtimeMs } = fs.statSync(file);
-        const relativePath = path.relative(opts.basePath, file);
-
-        let importsDeclarations = [];
-
-        if (cachedFiles[relativePath]) {
-            mergeProps(propNames, staticPropsList, cachedFiles[relativePath].propsList);
-            importsDeclarations = cachedFiles[relativePath].importsDeclarations;
-            cachedFiles[relativePath].reverseImports.push(...importPaths);
+    function _extractStaticValueImportedFilesFromFile(file, opts) {
+        if (cachedFiles[file]) {
+            mergeProps(propNames, staticPropsList, cachedFiles[file].propsList);
+            cachedFiles[file].reverseImports.push(topLevelFile);
         } else {
-            extractStaticValueFromFile(file, opts, (_staticPropsList, _importsDeclarations) => {
+            if (opts.include && !opts.include.find((includePath) => file.search(includePath) !== -1)) {
+                return;
+            }
+            const { mtimeMs } = fs.statSync(file);
+            extractStaticValueFromFile(file, opts, (_staticPropsList, importsDeclarations) => {
                 mergeProps(propNames, staticPropsList, _staticPropsList);
-                importsDeclarations = _importsDeclarations;
-                cachedFiles[relativePath] = {
+                cachedFiles[file] = {
                     cachedMtime: mtimeMs,
                     propsList: _staticPropsList,
                     importsDeclarations,
-                    reverseImports: importPaths,
+                    reverseImports: [topLevelFile],
                 };
             });
         }
 
-        importsDeclarations.forEach((file) => {
-            _extractStaticValueImportedFilesFromFile(file, opts, [...importPaths, relativePath]);
-        });
+        cachedFiles[file].importsDeclarations.forEach((f) => _extractStaticValueImportedFilesFromFile(f, opts));
     }
 
-    if (cachedFiles[relativePath]) {
-        staticPropsList = cachedFiles[relativePath].propsList;
-        cachedFiles[relativePath].reverseImports.push(...importPaths);
-    } else {
-        _extractStaticValueImportedFilesFromFile(file, opts, [...importPaths, relativePath]);
-        cachedFiles[relativePath] = {
+    
+    if (!cachedFiles[topLevelFile]) {
+        const { mtimeMs } = fs.statSync(topLevelFile);
+        _extractStaticValueImportedFilesFromFile(topLevelFile, opts);
+        cachedFiles[topLevelFile] = {
             cachedMtime: mtimeMs,
             propsList: staticPropsList,
             importsDeclarations: [],
-            reverseImports: importPaths,
+            reverseImports: [],
         };
     }
 
     propNames.forEach((name) => {
-        cachedFiles[relativePath].propsList[name] = [...new Set(cachedFiles[relativePath].propsList[name])];
+        cachedFiles[topLevelFile].propsList[name] = [...new Set(cachedFiles[topLevelFile].propsList[name])];
     });
 
-    cb(cachedFiles[relativePath].propsList);
+    cb(cachedFiles[topLevelFile].propsList);
 
-    return cachedFiles[relativePath].propsList;
+    return cachedFiles[topLevelFile].propsList;
 };
 
 export default (globArr, opts = {}) => {
@@ -158,7 +146,7 @@ export default (globArr, opts = {}) => {
     let previousContent;
 
     const staticValues = glob.sync(globArr).reduce((globObject, file) => {
-        const staticValues = extractStaticValueImportedFilesFromFile(file, opts);
+        const staticValues = extractStaticValueImportedFilesFromFile(path.relative(opts.basePath, file), opts);
         const dir = path.parse(file).dir;
         const componentName = dir.slice(dir.lastIndexOf('/') + PATH_DELIMITER_LENGTH);
 

--- a/src/persistentCache.js
+++ b/src/persistentCache.js
@@ -9,7 +9,7 @@ let cacheSaveTimeout;
 
 const getCacheFilePath = () => {
     const cacheDir = findCacheDir({ name: 'babel-plugin-static-value-extractor' }) || os.tmpdir();
-    return path.join(cacheDir, 'files.json');
+    return path.join(cacheDir, 'files_v2.json');
 }
 
 export const getPersistentCache = () => {


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-159843
После коммита https://github.com/hhru/hh.sites.main/commit/9e63af3c82096c65a5eade069be8f91acc5e169e сильно замедлилось извлечение переводов/фич. На мастере xhh сейчас первоначальное извлечение занимает ~80 сек, повторное в зависимости от файла тоже может доходить до 80 сек. При этом это блокирующая операция, вотч сборки статики не срабатывает до завершения процесса. Поэтому решил разобраться в чем дело и пофиксить.

Если коротко, то после того коммита количество вызовов функции `_extractStaticValueImportedFilesFromFile` на кодовой базе xhh увеличилось в ~4 раза (было 700 тыс вызовов, стало ~2.5 млн), поэтому сосредоточился на ее оптимизации. 

Основные изменения:
- Перенес вызов `fs.statSync` под условие, в ветку где он используется
- Сократил количество вызовов `path.relative`
- Переделал логику инвалидации кэша, теперь инвалидируется только кэш измененного файла и кэш "верхнеуровневого" (в xhh это страничные компоненты) файла к котором он относится. Раньше инвалидировалась вся цепочка файлов, от измененного до страничного компонента. Учитывая, что в кэше хранятся только собственные переводы/фичи файла, а для страничного компонента хранятся все фичи/переводы прямо или косвенно подключаемых в нем файлов, такое решение выглядит логичным.
- Из интересного - вызов `mergeProps` практически не влияет на время работы

Тестировал на мастере xhh, на стенде. Результаты:

Первоначальное извлечение (без кэша)
- до - 75-80 сек
- после - 15-16 сек

Изменение FullPageLayout (с кэшем):
- до - 60-65 сек
- после - 3 сек

Изменение IndexPageApplicant (с кэшем):
- до - 1.3 сек
- после - 0.4 сек

