### PR TITLE
HH-160795 fix cache invalidation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,15 +78,24 @@ export const prepareCache = (opts) => {
     const invalidPageComponents = [];
     invalidFiles.forEach((filePath) => {
         cachedFiles[filePath].importsDeclarations.forEach((file) => {
-            if (cachedFiles[file]) {
-                cachedFiles[file].reverseImports = cachedFiles[file].reverseImports.filter((file) => file !== filePath);
+            if (cachedFiles[file] && cachedFiles[file].reverseImports) {
+                cachedFiles[file].reverseImports = cachedFiles[file].reverseImports.filter(
+                    (file) => file !== filePath
+                );
             }
         });
         invalidPageComponents.push(...traceToPageComponent(filePath));
     });
 
+    new Set(invalidPageComponents).forEach((filePath) => {
+        cachedFiles[filePath].importsDeclarations.forEach((file) => {
+            if (cachedFiles[file] && cachedFiles[file].reverseImports) {
+                cachedFiles[file].reverseImports = cachedFiles[file].reverseImports.filter((file) => file !== filePath);
+            }
+        });
+        delete cachedFiles[filePath];
+    });
     invalidFiles.forEach((filePath) => delete cachedFiles[filePath]);
-    new Set(invalidPageComponents).forEach((filePath) => delete cachedFiles[filePath]);
 
     savePersistentCache(cachedFiles);
 };
@@ -192,9 +201,10 @@ export default (globArr, opts = {}) => {
         }
     });
 
-    Object.keys(cachedFiles).forEach((file) => 
-        cachedFiles[file].reverseImports =
-            cachedFiles[file].reverseImports === null ? null : [...new Set(cachedFiles[file].reverseImports)]
+    Object.keys(cachedFiles).forEach(
+        (file) =>
+            (cachedFiles[file].reverseImports =
+                cachedFiles[file].reverseImports === null ? null : [...new Set(cachedFiles[file].reverseImports)])
     );
     savePersistentCache(cachedFiles);
 };


### PR DESCRIPTION
https://mattermost.pyn.ru/hhru/pl/yke8njq86t8ozk7j57az9sxmqy

исключение выбрасывалось здесь https://github.com/hhru/babel-plugin-static-value-extractor/blob/master/src/index.js#L54

В кэше не было записей о страничных компонентах, но были ссылки на них в reverseImports компонентов
Как точно это случилось - непонятно, предполагаю что завершили процесс в момент когда кеш инвалидировали но не построили новый. Чтобы это предотвратить добавил в инвалидации проход по файлам подключаемым в страничных компонентах

