### PR TITLE
HH-208088 Fix extract values in webpack plugin

### DIFF
--- a/src/static-value-extractor-plugin.js
+++ b/src/static-value-extractor-plugin.js
@@ -57,12 +57,14 @@ class StaticValueExtractorPlugin {
             this.options.filesArr = filesArr;
         }
 
-        this.options = { ...this.options, ...otherParams, propsToExtract, include};
+        this.options = { ...this.options, ...otherParams, propsToExtract, include };
     }
 
     apply(compiler) {
-        compiler.hooks.done.tap('StaticValueExtractorPlugin', () => {
-            extractStaticValues(this.options);
+        compiler.hooks.done.tap('StaticValueExtractorPlugin', (stats) => {
+            if (!stats.hasErrors()) {
+                extractStaticValues(this.options);
+            }
         });
     }
 }


### PR DESCRIPTION
При разработке webpack плагина не учитывали, что разработчики совершают ошибки, и тогда  попытка выгрузить значения статических свойств терпит фиаско и кешируется. 

Исправил тем что не запускаю экстракт если в сборке есть ошибка.