### PR TITLE
HH-226548: exported traceToPageComponent for xhh util

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ const extractStaticValueFromCode = (code, opts = {}, cb = noop) => {
 
 let cachedFiles = getPersistentCache();
 
-const traceToPageComponent = (file) => {
+export const traceToPageComponent = (file) => {
     let parents = [file];
     let nextParents = [];
     const pageComponents = [];


### PR DESCRIPTION
Добавил экспорт функции traceToPageComponent, чтобы использовать её в утилите для определения страниц, где используется компонент (в xhh)
https://jira.hh.ru/browse/HH-226548